### PR TITLE
指定 webpack.base.conf 的 resolve.mainFields 字段

### DIFF
--- a/template/build/webpack.base.conf.js
+++ b/template/build/webpack.base.conf.js
@@ -46,7 +46,8 @@ module.exports = {
       'vue': 'mpvue',
       '@': resolve('src')
     },
-    symlinks: false
+    symlinks: false,
+    mainFields: ['browser', 'module', 'main']
   },
   module: {
     rules: [


### PR DESCRIPTION
防止引入 node 版本的依赖.
[#441](https://github.com/Meituan-Dianping/mpvue/issues/441)